### PR TITLE
추가 - Player 자동 디텍팅 / 수정 -  Arrow 파괴, Boss 페이즈 변환

### DIFF
--- a/Assets/Prefab/Boss.prefab
+++ b/Assets/Prefab/Boss.prefab
@@ -1,0 +1,210 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &470563014567634913
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 470563014567634937}
+  - component: {fileID: 470563014567634936}
+  - component: {fileID: 470563014567634939}
+  - component: {fileID: 470563014567634938}
+  - component: {fileID: 470563014567634941}
+  - component: {fileID: 470563014567634940}
+  - component: {fileID: 470563014567634943}
+  - component: {fileID: 470563014567634942}
+  m_Layer: 0
+  m_Name: Boss
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &470563014567634937
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 470563014567634913}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.01, y: 0.1, z: 0}
+  m_LocalScale: {x: 0.3, y: 0.3, z: 0.1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &470563014567634936
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 470563014567634913}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 3b0a03ed5c035934fbcae9c070970f8a, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 1
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 9.6, y: 9.6}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!95 &470563014567634939
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 470563014567634913}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 96d76f6ef982da342a9ddc2d855f96e2, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!61 &470563014567634938
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 470563014567634913}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 5.39, y: 7.5}
+    newSize: {x: 9.6, y: 9.6}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 9.6, y: 9.6}
+  m_EdgeRadius: 0
+--- !u!50 &470563014567634941
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 470563014567634913}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!114 &470563014567634940
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 470563014567634913}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 98a95776f706d9347a7561a900f19bf7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  detectionRadius: 10
+  player: {fileID: 0}
+  moveSpeed: 0.5
+--- !u!114 &470563014567634943
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 470563014567634913}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 738ca0d56a140f7449ba2cfa3a497729, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxHealth: 10
+  currentHealth: 0
+  knockbackForce: 0.1
+  hitColor: {r: 1, g: 1, b: 1, a: 0}
+--- !u!114 &470563014567634942
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 470563014567634913}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 33fc1e62513aa694c9a849eccc050caa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  phase: 1
+  attacking: 0
+  attackCooldown: 5
+  remainingAttackCooldown: 0
+  player: {fileID: 0}
+  arrow: {fileID: 7738489829350749990, guid: db18c82d8b2134a458466e838f633ac8, type: 3}
+  boss2: {fileID: 21300000, guid: 1431ea911ebfca74a9beb3506d8a4b49, type: 3}

--- a/Assets/Prefab/Boss.prefab.meta
+++ b/Assets/Prefab/Boss.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bd4aa0bcd8110684b8cc56c68eb08cb0
+guid: 88c643150e20cb24d8d6f69ebe8a4135
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Prefabs/Arrow.prefab
+++ b/Assets/Prefabs/Arrow.prefab
@@ -47,6 +47,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   direction: {x: 0, y: 0, z: 0}
   speed: 5
+  range: 20
 --- !u!1 &8409507424226290563
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/BasementEnd.unity
+++ b/Assets/Scenes/BasementEnd.unity
@@ -970,214 +970,11 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1 &1727812335
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1727812343}
-  - component: {fileID: 1727812342}
-  - component: {fileID: 1727812341}
-  - component: {fileID: 1727812340}
-  - component: {fileID: 1727812339}
-  - component: {fileID: 1727812338}
-  - component: {fileID: 1727812337}
-  - component: {fileID: 1727812336}
-  m_Layer: 0
-  m_Name: Boss
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1727812336
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1727812335}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 33fc1e62513aa694c9a849eccc050caa, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  phase: 1
-  attacking: 0
-  attackCooldown: 5
-  remainingAttackCooldown: 0
-  player: {fileID: 0}
-  arrow: {fileID: 7738489829350749990, guid: db18c82d8b2134a458466e838f633ac8, type: 3}
-  boss2: {fileID: 21300000, guid: 1431ea911ebfca74a9beb3506d8a4b49, type: 3}
---- !u!114 &1727812337
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1727812335}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 738ca0d56a140f7449ba2cfa3a497729, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  maxHealth: 10
-  currentHealth: 0
-  knockbackForce: 0.1
-  hitColor: {r: 1, g: 1, b: 1, a: 0}
---- !u!114 &1727812338
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1727812335}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 98a95776f706d9347a7561a900f19bf7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  detectionRadius: 10
-  player: {fileID: 0}
-  moveSpeed: 0.5
---- !u!50 &1727812339
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1727812335}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 0
-  m_Material: {fileID: 0}
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
---- !u!61 &1727812340
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1727812335}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 5.39, y: 7.5}
-    newSize: {x: 9.6, y: 9.6}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 9.6, y: 9.6}
-  m_EdgeRadius: 0
---- !u!95 &1727812341
-Animator:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1727812335}
-  m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: 96d76f6ef982da342a9ddc2d855f96e2, type: 2}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
---- !u!212 &1727812342
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1727812335}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 3b0a03ed5c035934fbcae9c070970f8a, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 1
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 9.6, y: 9.6}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &1727812343
+--- !u!4 &1727812343 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 470563014567634937, guid: 88c643150e20cb24d8d6f69ebe8a4135, type: 3}
+  m_PrefabInstance: {fileID: 470563016069477646}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1727812335}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.01, y: 0.1, z: 0}
-  m_LocalScale: {x: 0.3, y: 0.3, z: 0.1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 707481473}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1870903279
 GameObject:
   m_ObjectHideFlags: 0
@@ -1308,3 +1105,60 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1001 &470563016069477646
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 707481473}
+    m_Modifications:
+    - target: {fileID: 470563014567634913, guid: 88c643150e20cb24d8d6f69ebe8a4135, type: 3}
+      propertyPath: m_Name
+      value: Boss
+      objectReference: {fileID: 0}
+    - target: {fileID: 470563014567634937, guid: 88c643150e20cb24d8d6f69ebe8a4135, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 470563014567634937, guid: 88c643150e20cb24d8d6f69ebe8a4135, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 470563014567634937, guid: 88c643150e20cb24d8d6f69ebe8a4135, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 470563014567634937, guid: 88c643150e20cb24d8d6f69ebe8a4135, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 470563014567634937, guid: 88c643150e20cb24d8d6f69ebe8a4135, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 470563014567634937, guid: 88c643150e20cb24d8d6f69ebe8a4135, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 470563014567634937, guid: 88c643150e20cb24d8d6f69ebe8a4135, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 470563014567634937, guid: 88c643150e20cb24d8d6f69ebe8a4135, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 470563014567634937, guid: 88c643150e20cb24d8d6f69ebe8a4135, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 470563014567634937, guid: 88c643150e20cb24d8d6f69ebe8a4135, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 470563014567634937, guid: 88c643150e20cb24d8d6f69ebe8a4135, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 88c643150e20cb24d8d6f69ebe8a4135, type: 3}

--- a/Assets/Scenes/BossScene.unity
+++ b/Assets/Scenes/BossScene.unity
@@ -175,7 +175,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   detectionRadius: 10
-  player: {fileID: 1933256002}
   moveSpeed: 0.5
 --- !u!50 &510783522
 Rigidbody2D:
@@ -328,7 +327,6 @@ MonoBehaviour:
   attacking: 0
   attackCooldown: 5
   remainingAttackCooldown: 0
-  player: {fileID: 1933256002}
   arrow: {fileID: 7738489829350749990, guid: db18c82d8b2134a458466e838f633ac8, type: 3}
   boss2: {fileID: 21300000, guid: 1431ea911ebfca74a9beb3506d8a4b49, type: 3}
 --- !u!1 &813984719

--- a/Assets/Script/Arrow.cs
+++ b/Assets/Script/Arrow.cs
@@ -2,21 +2,28 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEditor.Experimental.GraphView;
 using UnityEngine;
+using static UnityEngine.GraphicsBuffer;
 
 public class Arrow : MonoBehaviour
 {
     public Vector3 direction;
     public float speed = 1f;
+    public float range = 5f;
+
+    public Vector3 SpawnPosition { get; set; }
+
+    private void Start()
+    {
+        
+    }
 
     private void Update()
     {
         transform.Translate(direction.normalized * speed * Time.deltaTime);
+        float distance = Vector2.Distance(transform.position, SpawnPosition);
+        if (distance >= range)
+        {
+            Destroy(gameObject);
+        }
     }
-
-
-    private void OnBecameInvisible()
-    {
-        Destroy(gameObject);
-    }
-
 }

--- a/Assets/Script/Health.cs
+++ b/Assets/Script/Health.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class Health : MonoBehaviour
+public class Health : MonoBehaviour, ISubject
 {
     public int maxHealth = 5;
     public int currentHealth;
@@ -10,6 +10,7 @@ public class Health : MonoBehaviour
     private Rigidbody2D rb;
     private SpriteRenderer spriteRenderer;
     public Color hitColor;
+    private List<IObserver> observers = new List<IObserver>();
 
     private void Start()
     {
@@ -34,6 +35,8 @@ public class Health : MonoBehaviour
             MoveBack();
             StartCoroutine(FlashSprite());
         }
+
+        NotifyObservers();
     }
 
     private void Die()
@@ -60,6 +63,24 @@ public class Health : MonoBehaviour
             yield return new WaitForSeconds(flashDuration / 2);
             GetComponent<SpriteRenderer>().color = originalColor;
             yield return new WaitForSeconds(flashDuration / 2);
+        }
+    }
+
+    public void ResisterObserver(IObserver observer)
+    {
+        observers.Add(observer);
+    }
+
+    public void RemoveObserver(IObserver observer)
+    {
+        observers.Remove(observer);
+    }
+
+    public void NotifyObservers()
+    {
+        foreach (var observer in observers)
+        {
+            observer.GetNotified();
         }
     }
 }

--- a/Assets/Script/IObserver.cs
+++ b/Assets/Script/IObserver.cs
@@ -1,0 +1,4 @@
+public interface IObserver
+{
+    void GetNotified();
+}

--- a/Assets/Script/IObserver.cs.meta
+++ b/Assets/Script/IObserver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3b066e47173856418e1b38fbd598512
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/ISubject.cs
+++ b/Assets/Script/ISubject.cs
@@ -1,0 +1,8 @@
+public interface ISubject
+{
+    void ResisterObserver(IObserver observer);
+
+    void RemoveObserver(IObserver observer);
+
+    void NotifyObservers();
+}

--- a/Assets/Script/ISubject.cs.meta
+++ b/Assets/Script/ISubject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d0b73df019e6dc44b910914480ef0ed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Monster.cs
+++ b/Assets/Script/Monster.cs
@@ -8,29 +8,33 @@ public class Monster : MonoBehaviour
     Rigidbody2D rb;
     SpriteRenderer spriteRenderer;
     public float detectionRadius; // 원의 반지름
-    public GameObject player; // 플레이어 레이어
     public float moveSpeed = 1.0f;
+
+    private GameObject[] players; // 플레이어 레이어
+    private GameObject target;
 
     private void Start()
     {
         animator = GetComponent<Animator>();
         spriteRenderer = GetComponent<SpriteRenderer>();
         rb = GetComponent<Rigidbody2D>();
+
+        players = GameObject.FindGameObjectsWithTag("Player");
     }
 
     private void Update()
     {
-        // 플레이어와 몬스터의 거리 계산
-        float distance = Vector2.Distance(transform.position, player.transform.position);
+        target = FindNearestPlayer();
 
-        if (distance <= detectionRadius) // 플레이어가 원 안에 있을 때
+        
+        if (IsTargetDetected()) // 플레이어가 원 안에 있을 때
         {
 
             Flip();// player 가 몬스터보다 왼쪽에 잇으면 flipt
 
             // 플레이어를 추적
             transform.position = Vector3.MoveTowards
-                (transform.position, player.transform.position, moveSpeed * Time.deltaTime);
+                (transform.position, target.transform.position, moveSpeed * Time.deltaTime);
 
             animator.SetBool("TrackingPlayer", true);
         }
@@ -47,11 +51,43 @@ public class Monster : MonoBehaviour
         Gizmos.DrawSphere(transform.position, detectionRadius);
     }
 
-    void Flip()
+    private GameObject FindNearestPlayer()
     {
-        if (player.transform.position.x < transform.position.x) { // 플레이어가 왼쪽에 있을 경우 filp
+        float minDistance = 0.0f;
+        GameObject result = null;
+        foreach (var player in players)
+        {
+            float distance = Vector2.Distance(transform.position, player.transform.position);
+            if (distance < minDistance || result == null)
+            {
+                distance = minDistance;
+                result = player;
+            }
+        }
+        return result;
+    }
+
+    private void Flip()
+    {
+        if (target.transform.position.x < transform.position.x) { // 플레이어가 왼쪽에 있을 경우 filp
             spriteRenderer.flipX = true;
         }
         else spriteRenderer.flipX = false;
+    }
+
+    public GameObject GetTarget()
+    {
+        return target;
+    }
+
+    public bool IsTargetDetected()
+    {
+        if (target == null) return false;
+
+        // 플레이어와 몬스터의 거리 계산
+        float distance = Vector2.Distance(transform.position, target.transform.position);
+
+
+        return distance <= detectionRadius;
     }
 }


### PR DESCRIPTION
Monster, BossMonster 스크립트에서 Inspecter로 받던 Player를 Tag로 찾도록 변경
Arrow 파괴 매커니즘을 SpawnPosition으로부터 일정 거리만큼 멀어지면 파괴되는 것으로 변경
보스 페이즈 변환에 쓰이는 BossMonster, Health 스크립트에 옵저버 패턴 적용